### PR TITLE
chore: unique files by appending uuid to ranged export csvs

### DIFF
--- a/main.go
+++ b/main.go
@@ -440,7 +440,7 @@ var app = &cli.App{
 						return fmt.Errorf("failed to create manifest, error: %s, date: %s", err, p.Date.String())
 					}
 
-					if err := processExport(ctx, em, shipPath); err != nil {
+					if err := processRangedExport(ctx, em, shipPath); err != nil {
 						processExportErrorsCounter.Inc()
 						logger.With("date", em.Period.Date.String(), "from", em.Period.StartHeight, "to", em.Period.EndHeight)
 						return fmt.Errorf("failed to process export: %s", err)


### PR DESCRIPTION
resolves #11 

This PR appends UUIDs to the **export files on the ship path**. This does so by adding a new field, `Unique`, to the `ExportFile` struct. There's a caveat to the `export` command and that is, it doesn't guarantee whether a table has been shipped since it easily cannot determine based on the file name and UUIDs whether that day has all of the epochs. 

For this PR, I would specifically like the following review from:

@iand
  - are the gauges still necessary here?
  - I'm not sure whether simply adding a field is considered correct in Golang here. Would it be better to actually embed `ExportFile` into another struct called `UniqueExportFile`?

@davidgasquez 
- can you please test this new branch?
- can you test whether the `run` command from `sentinel-archiver` still works as expected?